### PR TITLE
Add missing libraries to Alpine container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 COPY --from=signal /build/build/install/signal-cli/bin/ ./bin/
 COPY --from=signal /build/build/install/signal-cli/lib/ ./lib/
 COPY --from=receiver /build/alertmanager-signal-receiver ./bin/
-RUN apk add --no-cache libqrencode
+RUN apk add --no-cache libqrencode libgcc gcompat
 RUN mkdir ./data && chown -R nobody:nogroup ./data
 USER nobody:nogroup
 ENV PATH /app/bin:$PATH


### PR DESCRIPTION
Hello,

This is a fix for issue #1 .
We just add the missing libraries to the container image.