### PR TITLE
Add and configure locale to support emojis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,19 @@ WORKDIR /app
 ENV DEBIAN_FRONTEND noninteractive
 # without this directory the dpkg install script of openjdk fails
 RUN mkdir -p /usr/share/man/man1 && \
-apt-get update && apt-get install --no-install-recommends -y openjdk-16-jre-headless && \
-mkdir ./data && chown -R 1000:1000 ./data
+   apt-get update && \
+   apt-get install --no-install-recommends -y locales openjdk-16-jre-headless && \
+   mkdir ./data && \
+   chown -R 1000:1000 ./data && \
+   sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+   locale-gen
 COPY --from=signal-cli /build/signal-cli/bin/signal-cli ./bin/
 COPY --from=signal-cli /build/signal-cli/lib/ ./lib/
 COPY --from=alertmanager-signal-receiver /build/alertmanager-signal-receiver ./bin/
 ENV PATH /app/bin:$PATH
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 USER 1000:1000
 ENTRYPOINT ["alertmanager-signal-receiver"]
 EXPOSE 9709/tcp


### PR DESCRIPTION
Thank you for your project. I got it working today.

This adds the locale package and configures the locale to en_US.UTF-8 to
make emojis work with signal-cli.

As a workaround I had to use an ugly workaround like this (and yes, I've written a kubernetes helm chart :-)

```
      containers:
        - name: {{ .Chart.Name }}
          command:
            - /bin/bash
            - -xc
            - |
                # workaround POSIX locale for emoji support, too lazy to create own docker image
                apt update
                apt-get -y install locales
                sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
                export LC_ALL=en_US.UTF-8
                PATH=/app/bin:$PATH
                exec alertmanager-signal-receiver
          securityContext:
            runAsUser: 0
[...]
```